### PR TITLE
Commands needed to compile on vanilla sys

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,23 @@ To configure and build EPREM, then install the executable in your home directory
 ```
 Note that the `--` before `--prefix` is necessary to tell `setup.sh` that you wish to pass the `--prefix` argument to `configure.sh`. In fact, this is true of any argument that `configure.sh` accepts (see `./configure --help`).
 
-Although `setup.sh` intends to get you up and running as quickly as possible, you will likely need to specify some configuration options. In particular, you will need to point `configure.sh` to installations of [libconfig](http://hyperrealm.github.io/libconfig/) and [NetCDF4](https://unidata.github.io/netcdf4-python/) if they are not already in your `$PATH`. To do so, provide the `--with-libconfig-dir=...` and `--with-netcdf-dir=...` arguments. In the less likely event that there is no MPI distribution in your `$PATH`, you will need to provide the `--with-mpi-dir=...` argument. EPREM currently does not support serial operation (though it is possible in certain circumstances); `configure.sh` will do its best to find suitable MPI compilers without the need for explicitly setting `CC=..` and `CXX=...`, but if set-up fails, you may try doing so.
+Although `setup.sh` intends to get you up and running as quickly as possible, you will likely need to specify some configuration options. In particular, you will need to point `configure.sh` to installations of [libconfig](http://hyperrealm.github.io/libconfig/) and [NetCDF4](https://unidata.github.io/netcdf4-python/) if they are not already in your `$PATH`. To do so, provide the `--with-libconfig-dir=...` and `--with-netcdf-dir=...` arguments. In the less likely event that there is no MPI distribution in your `$PATH`, you will need to provide the `--with-mpi-dir=...` argument. 
+
+If your system is 'vanilla' (e.g., a new installation) and doesn't have support for autoconf, MPI, libconfig, or netCDF, you'll need to add them. For Debian-based systems (tested with 22.04 Ubuntu), you can run the following commands:
+
+$ sudo apt-get install autoconf
+$ sudo apt install mpich
+$ sudo apt install libconfig-dev
+$ sudo apt install libnetcdf-dev
+
+EPREM currently does not support serial operation (though it is possible in certain circumstances); `configure.sh` will do its best to find suitable MPI compilers without the need for explicitly setting `CC=..` and `CXX=...`, but if set-up fails, you may try doing so.
 
 Users familiar with the GNU Autotools are welcome to bypass `setup.sh` and directly run
 ```
 ./configure OPTIONS && make && make install
 ```
 with whichever `OPTIONS` they require.
+
+Finally, to verify that the installation was successful, run one of the examples, such as: 
+
+./eprem-latest cone.ini 


### PR DESCRIPTION
Added commands / info to install necessary support for autoconf, MPI, libconfig, and netCDF if the user is installing on a vanilla Ubuntu system. Also added a final 'verification' option by running the cone example.