### PR TITLE
Download dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Note that portions of this file have been copied or adapted from
 # (https://github.com/github/gitignore/blob/main/Autotools.gitignore).
 
+# Default directory for external dependencies
+ext-deps
+
 # Python files
 __pycache__
 

--- a/setup.sh
+++ b/setup.sh
@@ -273,10 +273,17 @@ install_ext_deps() {
         exit 1
     fi
     local deps_dir="${1}"
+    local tmp_name=tmp
 
-    # Create and enter the build directory for external dependencies.
-    mkdir ${deps_dir}
+    # Create and enter the top-level directory for external dependencies.
+    mkdir -p ${deps_dir}
     pushd ${deps_dir} &> /dev/null
+
+    # Create and enter the local subdirectory where this script will download
+    # and build each package. Isolating the source code allows us to remove it
+    # while leaving the build dependencies.
+    mkdir ${tmp_name}
+    pushd ${tmp_name} &> /dev/null
 
     # TODO: Refactor into a loop.
 
@@ -308,14 +315,18 @@ install_ext_deps() {
     ./configure --prefix="${deps_dir}" --disable-dap-remote-tests && make && make install && make check
     popd &> /dev/null
 
-    # Leave the external-dependencies directory.
+    # Exit and remove the temporary source-code directory.
+    popd &> /dev/null
+    /bin/rm -rf ${tmp_name}
+
+    # Exit the top-level external-dependencies directory.
     popd &> /dev/null
 }
 
 # Process the --download-ext-deps option.
 if [ "$download_deps" == 1 ]; then
     if [ -z "$deps_dir" ]; then
-        deps_dir="$(pwd)/external"
+        deps_dir="$(pwd)/ext-deps"
     fi
     install_ext_deps "${deps_dir}"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -284,28 +284,28 @@ install_ext_deps() {
     wget https://src.fedoraproject.org/repo/pkgs/libconfig/libconfig-1.5.tar.gz/a939c4990d74e6fc1ee62be05716f633/libconfig-1.5.tar.gz
     tar -xvzf libconfig-1.5.tar.gz
     pushd libconfig-1.5 &> /dev/null
-    ./configure --prefix=$(pwd)/../software && make && make install && make check
+    ./configure --prefix="${deps_dir}" && make && make install && make check
     popd &> /dev/null
 
     # --> zlib
     wget https://zlib.net/fossils/zlib-1.2.11.tar.gz
     tar -xvzf zlib-1.2.11.tar.gz
     pushd zlib-1.2.11 &> /dev/null
-    ./configure --prefix=$(pwd)/../software && make && make install && make check
+    ./configure --prefix="${deps_dir}" && make && make install && make check
     popd &> /dev/null
 
     # --> HDF5
     wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.17/src/hdf5-1.8.17.tar.gz
     tar -xvzf hdf5-1.8.17.tar.gz
     pushd hdf5-1.8.17 &> /dev/null
-    ./configure --prefix=$(pwd)/../software && make && make install && make check
+    ./configure --prefix="${deps_dir}" && make && make install && make check
     popd &> /dev/null
 
     # --> NetCDF4
     wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.4.1.1.tar.gz
     tar -xvzf v4.4.1.1.tar.gz
     pushd netcdf-c-4.4.1.1 &> /dev/null
-    ./configure --prefix=$(pwd)/../software --disable-dap-remote-tests && make && make install && make check
+    ./configure --prefix="${deps_dir}" --disable-dap-remote-tests && make && make install && make check
     popd &> /dev/null
 
     # Leave the external-dependencies directory.


### PR DESCRIPTION
* This update implements a `--download-ext-deps` option for `setup.sh`
* The option causes `setup.sh` to download and build all dependency packages